### PR TITLE
make webappdir configurable

### DIFF
--- a/solrcloudpy/connection.py
+++ b/solrcloudpy/connection.py
@@ -53,7 +53,7 @@ class SolrConnection(object):
             else:
                 self.servers = servers
         if type(server) == type([]):
-            servers = [self.url_template % a for a in server]
+            servers = [self.url_template.format(server=a) for a in server]
             if detect_live_nodes:
                 url = servers[0]
                 self.servers = self.detect_nodes(url)


### PR DESCRIPTION
a "url template" is introduced so one can use webapp dir other than the default '/solr'
