### PR TITLE
Use random access to pick a solr host that could share request loading to every host

### DIFF
--- a/solrcloudpy/utils.py
+++ b/solrcloudpy/utils.py
@@ -5,6 +5,7 @@ import requests
 import urlparse
 import json
 import itertools
+import random
 
 
 class _Request(object):

--- a/solrcloudpy/utils.py
+++ b/solrcloudpy/utils.py
@@ -44,7 +44,7 @@ class _Request(object):
         resparams = itertools.chain(params,
                                     extraparams.iteritems())
 
-        servers = random.shuffle(list(self.connection.servers))
+        random.shuffle(list(self.connection.servers))
         host = servers.pop(0)
 
         def make_request(host, path):

--- a/solrcloudpy/utils.py
+++ b/solrcloudpy/utils.py
@@ -1,4 +1,4 @@
-from requests.exceptions import ConnectionError
+from requests.exceptions import ConnectionError , Timeout
 from requests.auth import HTTPBasicAuth
 
 import requests
@@ -43,7 +43,7 @@ class _Request(object):
         resparams = itertools.chain(params,
                                     extraparams.iteritems())
 
-        servers = list(self.connection.servers)
+        servers = random.shuffle(list(self.connection.servers))
         host = servers.pop(0)
 
         def make_request(host, path):
@@ -55,7 +55,7 @@ class _Request(object):
 
                 return SolrResponse(r)
 
-            except ConnectionError as e:
+            except (Timeout , ConnectionError) as e:
                 print 'exception: ', e
                 host = servers.pop(0)
                 return make_request(host, path)

--- a/solrcloudpy/utils.py
+++ b/solrcloudpy/utils.py
@@ -1,11 +1,10 @@
-from requests.exceptions import ConnectionError , Timeout
+from requests.exceptions import ConnectionError
 from requests.auth import HTTPBasicAuth
 
 import requests
 import urlparse
 import json
 import itertools
-import random
 
 
 class _Request(object):
@@ -44,7 +43,8 @@ class _Request(object):
         resparams = itertools.chain(params,
                                     extraparams.iteritems())
 
-        random.shuffle(list(self.connection.servers))
+        servers = list(self.connection.servers)
+        random.shuffle(servers)
         host = servers.pop(0)
 
         def make_request(host, path):
@@ -56,7 +56,7 @@ class _Request(object):
 
                 return SolrResponse(r)
 
-            except (Timeout , ConnectionError) as e:
+            except ConnectionError as e:
                 print 'exception: ', e
                 host = servers.pop(0)
                 return make_request(host, path)


### PR DESCRIPTION
i just addd  'random.shuffle(servers)'
that could avoid always to pick first host 