### PR TITLE
Libraries shouldn't have script dependencies.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -33,6 +33,6 @@ setup(
         'Topic :: Internet :: WWW/HTTP :: Indexing/Search'
         ],
 
-    install_requires = ['requests == 2.2.1','IPython == 1.2.0'],
+    install_requires = ['requests >= 2.2.1','IPython >= 1.2.0'],
     extras_require = {"ip": ['IPython == 1.2.0'] },
         )


### PR DESCRIPTION
By pinning requests and ipython it prevents us from embedding this library into our application.