### PR TITLE
changed the way to generate dict for python2.6 compatibility

### DIFF
--- a/solrcloudpy/parameters.py
+++ b/solrcloudpy/parameters.py
@@ -286,5 +286,5 @@ class SearchOptions(object):
         return iter(res)
 
     def __repr__(self):
-        res = {c.__class__.__name__.lower(): c for c in self._all}
+        res = dict([(c.__class__.__name__.lower(), c) for c in self._all])
         return repr(res)


### PR DESCRIPTION
Hi, the syntax {c.__class__.__name__.lower(): c for c in self._all} is not supported in python2.6, can you make this change to make it python2.6 compatible. thanks.