### PR TITLE
generator gets consumed in the subsequent make_request, switched it to d...

### DIFF
--- a/solrcloudpy/utils.py
+++ b/solrcloudpy/utils.py
@@ -30,7 +30,7 @@ class _Request(object):
         :param method: Tje request method, e.g. `GET`
         :param body: The request body, if any
 
-        :returns response: an instance of :class:`~solrcloudpy.utils.SolrResponse` 
+        :returns response: an instance of :class:`~solrcloudpy.utils.SolrResponse`
         """
         headers = {'content-type': 'application/json'}
         extraparams = {'wt': 'json',
@@ -41,8 +41,8 @@ class _Request(object):
         if hasattr(params, 'iteritems'):
             params = params.iteritems()
 
-        resparams = itertools.chain(params,
-                                    extraparams.iteritems())
+        resparams = dict(itertools.chain(params,
+                                    extraparams.iteritems()))
 
         servers = list(self.connection.servers)
         random.shuffle(servers)


### PR DESCRIPTION
Hi, I just found another bug when testing a case where a node is down in the cloud. 

The second request is missing the params.

The reason is that resparams gets consumed in the first make_request call and becomes empty in the second make_request call. 

I fixed it and tested it, it is working for me. Not sure the way I did is the best way. You can change it if you have a better way. 