### PR TITLE
fix: UnboundLocalError when connection timeout happen

### DIFF
--- a/solrcloudpy/__init__.py
+++ b/solrcloudpy/__init__.py
@@ -4,5 +4,5 @@ from solrcloudpy.parameters import SearchOptions
 import logging
 logging.basicConfig()
 
-__version__ = "3.0.0"
+__version__ = "3.0.1"
 __all__ = ['SolrCollection', 'SolrConnection', 'SearchOptions']

--- a/solrcloudpy/utils.py
+++ b/solrcloudpy/utils.py
@@ -98,6 +98,7 @@ class _Request(object):
             raise SolrException("No servers available")
 
         result = None
+        r = None
         while result is None:
             host = random.choice(servers)
             fullpath = urljoin(host, path)


### PR DESCRIPTION
In previous PR to support python3, I added:

```
finally:
  # avoid requests library's keep alive throw exception in python3
  if r is not None and r.connection:
    r.connection.close()
```

to close the connection when a request is done. This is actually optional to avoid showing warning in python3, which encourage stricter resource managing. But when the requests.request timeout or when other exception happens the `r` will be unbound in this block. Which will throw:

`UnboundLocalError: local variable 'r' referenced before assignment`

This PR should fix it. Sorry for the sloppy change.